### PR TITLE
increase memory limits

### DIFF
--- a/system/argocdcore/values.yaml
+++ b/system/argocdcore/values.yaml
@@ -35,10 +35,10 @@ argo-cd:
     resources:
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1024Mi
       requests:
         cpu: 250m
-        memory: 256Mi
+        memory: 512Mi
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
Increase memory limits because of OOMKilled with shared cluster || reach certain number of applications.