### PR TITLE
remove: endpoint_port_name label reference

### DIFF
--- a/monitoring/victoria-metrics-operator-vmagent/templates/vmagent-additional-scrape-config.yaml
+++ b/monitoring/victoria-metrics-operator-vmagent/templates/vmagent-additional-scrape-config.yaml
@@ -48,7 +48,6 @@ stringData:
             [
               __meta_kubernetes_namespace,
               __meta_kubernetes_service_name,
-              __meta_kubernetes_endpoint_port_name,
             ]
           action: keep
           regex: default;kubernetes;https


### PR DESCRIPTION
remove  __meta_kubernetes_endpoint_port_name
this label is not provided currently